### PR TITLE
Fixed cross origin error

### DIFF
--- a/src/main/java/com/example/backend/interface_adapters/ClaimsViewController.java
+++ b/src/main/java/com/example/backend/interface_adapters/ClaimsViewController.java
@@ -4,11 +4,13 @@ import com.example.backend.responsemodel.ClaimBaseModel;
 import com.example.backend.responsemodel.CommonListResponse;
 import com.example.backend.use_case.claimsView.ClaimsViewService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@CrossOrigin(origins = "*")
 public class ClaimsViewController {
 
     @Autowired

--- a/src/main/java/com/example/backend/interface_adapters/fileUploadController.java
+++ b/src/main/java/com/example/backend/interface_adapters/fileUploadController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
+@CrossOrigin(origins = "*")
 public class fileUploadController {
     @Autowired
     private com.example.backend.use_case.fileUpload.fileUploadService fileUploadService;


### PR DESCRIPTION
## Pull Request

### Description

There was a bug in the "/claims" and "file/upload" endpoints where requests made were blocked by the CORS policy set at backend.

### Related Issues

<!--- Link to any related GitHub issues that this PR addresses or resolves. -->
<!--- For example: "Resolves #123", "Addresses #456", "See also #789" -->

Resolves #39

### Changes Made

<!--- Summarize the changes you made in this pull request. -->
So the only change needed was that I needed to add a ```@CrossOrigin(origins = "*")``` on each controllers that enables cross origin requests from all browsers. So there should be no CORS errors.

### Checklist

<!--- -->

- [x] I have tested the changes locally.
- [x] My code follows the project's coding style.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.

### Additional Notes (if any)

Try making a request from the front-end to confirm
